### PR TITLE
Makes upside down feature compatible with tas

### DIFF
--- a/ExtendedVariantMode/UI/AbstractSubmenu.cs
+++ b/ExtendedVariantMode/UI/AbstractSubmenu.cs
@@ -134,7 +134,7 @@ namespace ExtendedVariants.UI {
         }
 
         private static T getOrInstantiateSubmenu<T>() where T : AbstractSubmenu {
-            if (OuiModOptions.Instance?.Overworld == null) {
+            if (OuiModOptions.Instance?.Overworld.GetUI<T>() == null) {
                 // this is a very edgy edge case. but it still might happen. :maddyS:
                 Logger.Log(LogLevel.Warn, "ExtendedVariantMode/AbstractSubmenu", $"Overworld does not exist, instanciating submenu {typeof(T)} on the spot!");
                 return (T) Activator.CreateInstance(typeof(T));


### PR DESCRIPTION
Because the level.Render() method will be ignored when tas fast forwarding, set invertedY in level.Update() method as well for compatibility with tas.

BTW dont know why the invertedY will be reset to false every frame.