### PR TITLE
New variant: No freeze frames

### DIFF
--- a/ExtendedVariantMode/Ahorn/libraries/extendedVariantDictionary.jl
+++ b/ExtendedVariantMode/Ahorn/libraries/extendedVariantDictionary.jl
@@ -67,6 +67,7 @@ const Variants = String[
 	"JellyfishEverywhere",
 	"JumpCount",
 	"JumpHeight",
+	"NoFreezeFrames",
 	"OshiroCount",
 	"OshiroEverywhere",
 	"RefillJumpsOnDashRefill",

--- a/ExtendedVariantMode/Dialog/English.txt
+++ b/ExtendedVariantMode/Dialog/English.txt
@@ -241,6 +241,9 @@ MODOPTIONS_EXTENDEDVARIANTS_EVERYJUMPISULTRA_DESC=	Get a 1.2x horizontal speed b
 MODOPTIONS_EXTENDEDVARIANTS_COYOTETIME=	Coyote Time
 MODOPTIONS_EXTENDEDVARIANTS_COYOTETIME_DESC=	Time during which you can jump in midair after walking off a platform
 
+MODOPTIONS_EXTENDEDVARIANTS_NOFREEZEFRAMES=	No Freeze Frames
+MODOPTIONS_EXTENDEDVARIANTS_NOFREEZEFRAMES_DESC=	Don't freeze the game for a few frames when dashing, collecting a refill, etc.
+
 MODOPTIONS_EXTENDEDVARIANTS_AutomaticallyResetVariants= Automatically Reset Variants
 MODOPTIONS_EXTENDEDVARIANTS_AutomaticallyResetVariants_description= when entering a map using Extended Variants
 

--- a/ExtendedVariantMode/ExtendedVariantMode.csproj
+++ b/ExtendedVariantMode/ExtendedVariantMode.csproj
@@ -162,6 +162,7 @@
     <Compile Include="Variants\DisableNeutralJumping.cs" />
     <Compile Include="Variants\DisplayDashCount.cs" />
     <Compile Include="Variants\EveryJumpIsUltra.cs" />
+    <Compile Include="Variants\NoFreezeFrames.cs" />
     <Compile Include="Variants\InvertVerticalControls.cs" />
     <Compile Include="Variants\MadelineBackpackMode.cs" />
     <Compile Include="Variants\MadelineHasPonytail.cs" />

--- a/ExtendedVariantMode/Module/ExtendedVariantsModule.cs
+++ b/ExtendedVariantMode/Module/ExtendedVariantsModule.cs
@@ -47,7 +47,7 @@ namespace ExtendedVariants.Module {
             BounceEverywhere, SuperdashSteeringSpeed, ScreenShakeIntensity, AnxietyEffect, BlurLevel, ZoomLevel, DashDirection, BackgroundBrightness, DisableMadelineSpotlight,
             ForegroundEffectOpacity, MadelineIsSilhouette, DashTrailAllTheTime, DisableClimbingUpOrDown, SwimmingSpeed, BoostMultiplier, FriendlyBadelineFollower,
             DisableRefillsOnScreenTransition, RestoreDashesOnRespawn, DisableSuperBoosts, DisplayDashCount, MadelineHasPonytail, MadelineBackpackMode, InvertVerticalControls,
-            DontRefillStaminaOnGround, EveryJumpIsUltra, CoyoteTime, BackgroundBlurLevel
+            DontRefillStaminaOnGround, EveryJumpIsUltra, CoyoteTime, BackgroundBlurLevel, NoFreezeFrames
         }
 
         public Dictionary<Variant, AbstractExtendedVariant> VariantHandlers = new Dictionary<Variant, AbstractExtendedVariant>();
@@ -150,6 +150,7 @@ namespace ExtendedVariants.Module {
             VariantHandlers[Variant.MadelineBackpackMode] = new MadelineBackpackMode();
             VariantHandlers[Variant.EveryJumpIsUltra] = new EveryJumpIsUltra();
             VariantHandlers[Variant.CoyoteTime] = new CoyoteTime();
+            VariantHandlers[Variant.NoFreezeFrames] = new NoFreezeFrames();
         }
 
         // ================ Mod options setup ================

--- a/ExtendedVariantMode/Module/ExtendedVariantsSettings.cs
+++ b/ExtendedVariantMode/Module/ExtendedVariantsSettings.cs
@@ -406,6 +406,11 @@ namespace ExtendedVariants.Module {
         // ======================================
 
         [SettingIgnore]
+        public bool NoFreezeFrames { get; set; } = false;
+
+        // ======================================
+
+        [SettingIgnore]
         public bool ChangeVariantsRandomly { get; set; } = false;
 
         [SettingIgnore]

--- a/ExtendedVariantMode/UI/ModOptionsEntries.cs
+++ b/ExtendedVariantMode/UI/ModOptionsEntries.cs
@@ -114,6 +114,7 @@ namespace ExtendedVariants.UI {
         private TextMenu.Option<bool> everyJumpIsUltraOption;
         private TextMenu.Option<int> madelineBackpackModeOption;
         private TextMenu.Option<int> coyoteTimeOption;
+        private TextMenu.Option<bool> noFreezeFramesOption;
         private TextMenu.Item resetExtendedToDefaultOption;
         private TextMenu.Item resetVanillaToDefaultOption;
         private TextMenu.Item randomizerOptions;
@@ -633,6 +634,9 @@ namespace ExtendedVariants.UI {
                 gameSpeedOption = new TextMenuExt.Slider(Dialog.Clean("MODOPTIONS_EXTENDEDVARIANTS_GAMESPEED"),
                     multiplierFormatter, 0, multiplierScale.Length - 1, indexFromMultiplier(Settings.GameSpeed), indexFromMultiplier(10)).Change(i => Settings.GameSpeed = multiplierScale[i]);
 
+                noFreezeFramesOption = new TextMenuExt.OnOff(Dialog.Clean("MODOPTIONS_EXTENDEDVARIANTS_NOFREEZEFRAMES"), Settings.NoFreezeFrames, false)
+                    .Change(b => Settings.NoFreezeFrames = b);
+
                 everythingIsUnderwaterOption = new TextMenuExt.OnOff(Dialog.Clean("MODOPTIONS_EXTENDEDVARIANTS_EVERYTHINGISUNDERWATER"), Settings.EverythingIsUnderwater, false)
                     .Change(b => Settings.EverythingIsUnderwater = b);
 
@@ -742,7 +746,7 @@ namespace ExtendedVariants.UI {
                         .Exists(variant => Instance.VariantHandlers.ContainsKey(variant) && Instance.VariantHandlers[variant].GetValue() != Instance.VariantHandlers[variant].GetDefaultValue());
 
                 gameplayTweaksSubmenu.GetHighlight = () =>
-                    new List<Variant> { Variant.GameSpeed, Variant.EverythingIsUnderwater, Variant.Stamina, Variant.RegularHiccups, Variant.AllStrawberriesAreGoldens,
+                    new List<Variant> { Variant.GameSpeed, Variant.NoFreezeFrames, Variant.EverythingIsUnderwater, Variant.Stamina, Variant.RegularHiccups, Variant.AllStrawberriesAreGoldens,
                         Variant.ForceDuckOnGround, Variant.InvertDashes, Variant.InvertGrab, Variant.InvertHorizontalControls, Variant.InvertVerticalControls, Variant.BounceEverywhere }
                         .Exists(variant => Instance.VariantHandlers[variant].GetValue() != Instance.VariantHandlers[variant].GetDefaultValue())
                         || Settings.HiccupStrength != 10;
@@ -773,7 +777,7 @@ namespace ExtendedVariants.UI {
                 disableMadelineSpotlightOption, foregroundEffectOpacityOption, madelineIsSilhouetteOption, dashTrailAllTheTimeOption, disableClimbingUpOrDownOption, allowThrowingTheoOffscreenOption,
                 allowLeavingTheoBehindOption, boostMultiplierOption, resetVanillaToDefaultOption, friendlyBadelineFollowerOption, dashDirectionsSubMenu, disableRefillsOnScreenTransitionOption,
                 restoreDashesOnRespawnOption, disableSuperBoostsOption, displayDashCountOption, madelineHasPonytailOption, madelineBackpackModeOption, invertVerticalControlsOption, dontRefillStaminaOnGroundOption,
-                everyJumpIsUltraOption, coyoteTimeOption, backgroundBlurLevelOption };
+                everyJumpIsUltraOption, coyoteTimeOption, backgroundBlurLevelOption, noFreezeFramesOption };
 
             refreshOptionMenuEnabledStatus();
 
@@ -919,6 +923,8 @@ namespace ExtendedVariants.UI {
             if (category == VariantCategory.All || category == VariantCategory.GameplayTweaks) {
                 menu.Add(otherTitle);
                 menu.Add(gameSpeedOption);
+                menu.Add(noFreezeFramesOption);
+                noFreezeFramesOption.AddDescription(menu, Dialog.Clean("MODOPTIONS_EXTENDEDVARIANTS_NOFREEZEFRAMES_DESC"));
                 menu.Add(everythingIsUnderwaterOption);
                 menu.Add(staminaOption);
                 menu.Add(regularHiccupsOption);
@@ -1035,6 +1041,7 @@ namespace ExtendedVariants.UI {
             setValue(displayDashCountOption, Settings.DisplayDashCount);
             setValue(everyJumpIsUltraOption, Settings.EveryJumpIsUltra);
             setValue(coyoteTimeOption, 0, indexFromMultiplier(Settings.CoyoteTime));
+            setValue(noFreezeFramesOption, Settings.NoFreezeFrames);
         }
 
         private void refreshOptionMenuEnabledStatus() {

--- a/ExtendedVariantMode/VariantRandomizer.cs
+++ b/ExtendedVariantMode/VariantRandomizer.cs
@@ -376,6 +376,7 @@ namespace ExtendedVariants {
             else if (variant == ExtendedVariantsModule.Variant.DisplayDashCount) ExtendedVariantsModule.Settings.DisplayDashCount = true;
             else if (variant == ExtendedVariantsModule.Variant.DontRefillStaminaOnGround) ExtendedVariantsModule.Settings.DontRefillStaminaOnGround = true;
             else if (variant == ExtendedVariantsModule.Variant.EveryJumpIsUltra) ExtendedVariantsModule.Settings.EveryJumpIsUltra = true;
+            else if (variant == ExtendedVariantsModule.Variant.NoFreezeFrames) ExtendedVariantsModule.Settings.NoFreezeFrames = true;
             // multiplier-style variants (random 0~3x)
             else if (variant == ExtendedVariantsModule.Variant.Gravity) ExtendedVariantsModule.Settings.Gravity = multiplierScale[randomGenerator.Next(23)];
             else if (variant == ExtendedVariantsModule.Variant.FallSpeed) ExtendedVariantsModule.Settings.FallSpeed = multiplierScale[randomGenerator.Next(23)];

--- a/ExtendedVariantMode/Variants/NoFreezeFrames.cs
+++ b/ExtendedVariantMode/Variants/NoFreezeFrames.cs
@@ -1,0 +1,55 @@
+﻿using Celeste.Mod;
+using MonoMod.Cil;
+using System;
+using Monocle;
+
+namespace ExtendedVariants.Variants {
+    public class NoFreezeFrames : AbstractExtendedVariant {
+
+        public override int GetDefaultValue() {
+            return 0;
+        }
+
+        public override int GetValue() {
+            return Settings.NoFreezeFrames ? 1 : 0;
+        }
+
+        public override void SetValue(int value) {
+            Settings.NoFreezeFrames = (value != 0);
+        }
+
+        public override void Load() {
+            IL.Monocle.Engine.Update += modEngineUpdate;
+            On.Celeste.Celeste.Freeze += onCelesteFreeze;
+        }
+
+        public override void Unload() {
+            IL.Monocle.Engine.Update -= modEngineUpdate;
+            On.Celeste.Celeste.Freeze -= onCelesteFreeze;
+        }
+
+        private void onCelesteFreeze(On.Celeste.Celeste.orig_Freeze orig, float time) {
+            if (Settings.NoFreezeFrames) {
+                return;
+            }
+            orig(time);
+        }
+
+        private void modEngineUpdate(ILContext il) {
+            ILCursor cursor = new ILCursor(il);
+
+            if (cursor.TryGotoNext(MoveType.Before,
+                instr => instr.MatchLdsfld(typeof(Engine), nameof(Engine.FreezeTimer)))
+            ) {
+                Logger.Log("ExtendedVariantMode/NoFreezeFrames", $"Modding no freeze frames at index {cursor.Index} in CIL code for {cursor.Method.Name}");
+
+                cursor.EmitDelegate<Action>(() => {
+                    if (Settings.NoFreezeFrames) {
+                        Engine.FreezeTimer = 0f;
+                    }
+                });
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
Add a new "No freeze frames" variant that removes freeze frames when dashing, collecting refill crystals, etc.

Currently there are two ways to freeze the game:

1. By calling `Celeste.Freeze(time)`, this will also advance the cassette music if current room has cassette blocks.
2. By setting `Engine.FreezeTimer` field, this will not advance the cassette music.

Unfortunately both ways are used in vanilla (although the second one should never be used), and I can't think of a way to multiply the freeze frames if it's set by second way, so I only create a on / off toggle for this variant.

French translation for variant title and description is missing.