### PR TITLE
Apply liftboost to protected cornerboosts

### DIFF
--- a/Variants/CornerboostProtection.cs
+++ b/Variants/CornerboostProtection.cs
@@ -90,8 +90,10 @@ namespace ExtendedVariants.Variants {
                 || !TryGetPlayerData(player, out var data) || !data.SafeCornerboostReady)
                 return;
 
-            if (Input.MoveX == Math.Sign(player.wallSpeedRetained))
-                player.wallSpeedRetained += 40f * Input.MoveX;
+            float addSpeed = 40f * Input.MoveX + player.LiftBoost.X;
+
+            if (Math.Sign(addSpeed) == Math.Sign(player.wallSpeedRetained))
+                player.wallSpeedRetained += addSpeed;
 
             data.SafeCornerboostReady = false;
         }

--- a/everest.yaml
+++ b/everest.yaml
@@ -1,5 +1,5 @@
 - Name: ExtendedVariantMode
-  Version: 0.50.2
+  Version: 0.50.3
   DLL: bin/ExtendedVariantMode.dll
   Dependencies:
     - Name: Everest


### PR DESCRIPTION
Changed Cornerboost Protection so that liftboost also gets added to retained wallspeed